### PR TITLE
Add autoassign plugin for GLPI 9.5.5

### DIFF
--- a/glpi/plugins/autoassign/front/config.form.php
+++ b/glpi/plugins/autoassign/front/config.form.php
@@ -1,0 +1,52 @@
+<?php
+
+include '../../../inc/includes.php';
+
+global $CFG_GLPI;
+
+Session::checkRight('config', READ);
+
+$plugin = new Plugin();
+if (!$plugin->isInstalled('autoassign') || !$plugin->isActivated('autoassign')) {
+    Html::displayNotFoundError();
+}
+
+$config = new PluginAutoassignConfig();
+
+if (isset($_POST['add'])) {
+    $config->check(-1, CREATE, $_POST);
+    $config->add($_POST);
+    Html::redirect($CFG_GLPI['root_doc'] . '/plugins/autoassign/front/config.form.php');
+}
+
+if (isset($_POST['update'])) {
+    $config->check($_POST['id'], UPDATE);
+    $config->update($_POST);
+    Html::redirect($CFG_GLPI['root_doc'] . '/plugins/autoassign/front/config.form.php');
+}
+
+if (isset($_POST['delete'])) {
+    $config->check($_POST['id'], DELETE);
+    $config->delete($_POST);
+    Html::redirect($CFG_GLPI['root_doc'] . '/plugins/autoassign/front/config.form.php');
+}
+
+if (isset($_POST['purge'])) {
+    $config->check($_POST['id'], PURGE);
+    $config->delete($_POST, true);
+    Html::redirect($CFG_GLPI['root_doc'] . '/plugins/autoassign/front/config.form.php');
+}
+
+$ID = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+
+Html::header(__('Auto Assign & ShowAll', 'autoassign'), $_SERVER['PHP_SELF'], 'config', 'plugins', 'autoassign');
+
+echo "<div class='spaced'>";
+$config->showForm($ID);
+echo '</div>';
+
+echo "<div class='spaced'>";
+Search::show('PluginAutoassignConfig');
+echo '</div>';
+
+Html::footer();

--- a/glpi/plugins/autoassign/hook.php
+++ b/glpi/plugins/autoassign/hook.php
@@ -1,0 +1,160 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die('Sorry. You can\'t access directly to this file');
+}
+
+function plugin_autoassign_force_showall($params = [])
+{
+    $userID = Session::getLoginUserID();
+
+    if (empty($userID)) {
+        return;
+    }
+
+    if (plugin_autoassign_user_matches_rule((int) $userID, 'force_showall')) {
+        $_SESSION['glpishowallentities'] = 1;
+    }
+}
+
+function plugin_autoassign_post_item_add(CommonDBTM $item)
+{
+    if (!($item instanceof TicketTask)) {
+        return;
+    }
+
+    $userID   = (int) ($item->fields['users_id_tech'] ?? 0);
+    $ticketID = (int) ($item->fields['tickets_id'] ?? 0);
+
+    if ($userID <= 0 || $ticketID <= 0) {
+        return;
+    }
+
+    if (!plugin_autoassign_user_matches_rule($userID, 'autoassign_task')) {
+        return;
+    }
+
+    global $DB;
+
+    $existing = $DB->request([
+        'FROM'  => 'glpi_tickets_users',
+        'WHERE' => [
+            'tickets_id' => $ticketID,
+            'users_id'   => $userID,
+            'type'       => CommonITILActor::ASSIGN,
+        ],
+        'LIMIT' => 1,
+    ]);
+
+    if ($existing) {
+        foreach ($existing as $row) {
+            return;
+        }
+    }
+
+    $ticketUser = new Ticket_User();
+    $ticketUser->add([
+        'tickets_id' => $ticketID,
+        'users_id'   => $userID,
+        'type'       => CommonITILActor::ASSIGN,
+    ]);
+}
+
+function plugin_autoassign_user_matches_rule($userID, $flagField)
+{
+    global $DB;
+
+    if ($userID <= 0) {
+        return false;
+    }
+
+    $memberships = plugin_autoassign_get_user_memberships($userID);
+
+    if (empty($memberships)) {
+        return false;
+    }
+
+    $iterator = $DB->request([
+        'FROM'  => 'glpi_plugin_autoassign_config',
+        'WHERE' => [
+            $flagField => 1,
+        ],
+    ]);
+
+    foreach ($iterator as $rule) {
+        $profileID = isset($rule['profiles_id']) ? (int) $rule['profiles_id'] : null;
+        $groupID   = isset($rule['groups_id']) ? (int) $rule['groups_id'] : null;
+        $entityID  = isset($rule['entities_id']) ? (int) $rule['entities_id'] : null;
+
+        if ($profileID && in_array($profileID, $memberships['profiles'], true)) {
+            return true;
+        }
+
+        if ($groupID && in_array($groupID, $memberships['groups'], true)) {
+            return true;
+        }
+
+        if ($entityID !== null && in_array($entityID, $memberships['entities'], true)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function plugin_autoassign_get_user_memberships($userID)
+{
+    global $DB;
+
+    static $cache = [];
+
+    if (isset($cache[$userID])) {
+        return $cache[$userID];
+    }
+
+    $profiles = [];
+    $groups   = [];
+    $entities = [];
+
+    $profileIterator = $DB->request([
+        'SELECT' => ['profiles_id', 'entities_id'],
+        'FROM'   => 'glpi_profiles_users',
+        'WHERE'  => ['users_id' => $userID],
+    ]);
+
+    foreach ($profileIterator as $row) {
+        if ($row['profiles_id'] !== null) {
+            $profiles[] = (int) $row['profiles_id'];
+        }
+        if ($row['entities_id'] !== null) {
+            $entities[] = (int) $row['entities_id'];
+        }
+    }
+
+    $groupIterator = $DB->request([
+        'SELECT' => 'groups_id',
+        'FROM'   => 'glpi_groups_users',
+        'WHERE'  => ['users_id' => $userID],
+    ]);
+
+    foreach ($groupIterator as $row) {
+        if ($row['groups_id'] !== null) {
+            $groups[] = (int) $row['groups_id'];
+        }
+    }
+
+    $user = new User();
+    if ($user->getFromDB($userID)) {
+        if (isset($user->fields['entities_id']) && $user->fields['entities_id'] !== null) {
+            $entities[] = (int) $user->fields['entities_id'];
+        }
+    }
+
+    $cache[$userID] = [
+        'profiles' => array_values(array_unique($profiles)),
+        'groups'   => array_values(array_unique($groups)),
+        'entities' => array_values(array_unique($entities)),
+    ];
+
+    return $cache[$userID];
+}

--- a/glpi/plugins/autoassign/inc/autoassign.class.php
+++ b/glpi/plugins/autoassign/inc/autoassign.class.php
@@ -1,0 +1,129 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die('Sorry. You can\'t access directly to this file');
+}
+
+class PluginAutoassignConfig extends CommonDBTM
+{
+    public static $rightname = 'config';
+
+    protected $table = 'glpi_plugin_autoassign_config';
+
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Auto assign rule', 'Auto assign rules', $nb, 'autoassign');
+    }
+
+    public function prepareInputForAdd($input)
+    {
+        $input = parent::prepareInputForAdd($input);
+        if ($input === false) {
+            return false;
+        }
+
+        return $this->sanitizeInput($input);
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        $input = parent::prepareInputForUpdate($input);
+        if ($input === false) {
+            return false;
+        }
+
+        return $this->sanitizeInput($input);
+    }
+
+    private function sanitizeInput(array $input)
+    {
+        foreach (['profiles_id', 'groups_id', 'entities_id'] as $field) {
+            if (!array_key_exists($field, $input)) {
+                continue;
+            }
+
+            if ($input[$field] === '' || $input[$field] === null) {
+                $input[$field] = null;
+                continue;
+            }
+
+            $value = (int) $input[$field];
+
+            if ($field === 'entities_id') {
+                $input[$field] = $value;
+            } else {
+                $input[$field] = $value > 0 ? $value : null;
+            }
+        }
+
+        $input['force_showall']   = isset($input['force_showall']) ? 1 : 0;
+        $input['autoassign_task'] = isset($input['autoassign_task']) ? 1 : 0;
+
+        return $input;
+    }
+
+    public function showForm($ID, array $options = [])
+    {
+        if ($ID > 0) {
+            $this->check($ID, READ);
+        } else {
+            $this->check(-1, CREATE);
+        }
+
+        $this->initForm($ID, $options);
+        $this->showFormHeader($options);
+
+        echo "<tr class='tab_bg_1'>";
+        echo '<td>' . __('Profile') . '</td>';
+        echo '<td>';
+        Profile::dropdown([
+            'name'                  => 'profiles_id',
+            'value'                 => $this->fields['profiles_id'] ?? 0,
+            'display_emptychoice'   => true,
+            'checkright'            => false,
+        ]);
+        echo '</td>';
+        echo '<td>' . __('Force show all entities', 'autoassign') . '</td>';
+        echo '<td>';
+        Html::showCheckbox([
+            'name'    => 'force_showall',
+            'checked' => !empty($this->fields['force_showall']),
+        ]);
+        echo '</td>';
+        echo '</tr>';
+
+        echo "<tr class='tab_bg_1'>";
+        echo '<td>' . __('Group') . '</td>';
+        echo '<td>';
+        Group::dropdown([
+            'name'                => 'groups_id',
+            'value'               => $this->fields['groups_id'] ?? 0,
+            'display_emptychoice' => true,
+        ]);
+        echo '</td>';
+        echo '<td>' . __('Auto assign task technician', 'autoassign') . '</td>';
+        echo '<td>';
+        Html::showCheckbox([
+            'name'    => 'autoassign_task',
+            'checked' => !empty($this->fields['autoassign_task']),
+        ]);
+        echo '</td>';
+        echo '</tr>';
+
+        echo "<tr class='tab_bg_1'>";
+        echo '<td>' . __('Entity') . '</td>';
+        echo '<td>';
+        Entity::dropdown([
+            'name'                => 'entities_id',
+            'value'               => $this->fields['entities_id'] ?? 0,
+            'display_emptychoice' => true,
+        ]);
+        echo '</td>';
+        echo '<td colspan="2"></td>';
+        echo '</tr>';
+
+        $this->showFormButtons($options);
+
+        return true;
+    }
+}

--- a/glpi/plugins/autoassign/setup.php
+++ b/glpi/plugins/autoassign/setup.php
@@ -1,0 +1,98 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die('Sorry. You can\'t access directly to this file');
+}
+
+define('PLUGIN_AUTOASSIGN_VERSION', '1.0.0');
+
+function plugin_version_autoassign()
+{
+    return [
+        'name'           => __('Auto Assign & ShowAll', 'autoassign'),
+        'version'        => PLUGIN_AUTOASSIGN_VERSION,
+        'author'         => 'Autoassign Plugin Generator',
+        'license'        => 'GPLv2+',
+        'homepage'       => 'https://example.com',
+        'minGlpiVersion' => '9.5.5',
+    ];
+}
+
+function plugin_autoassign_check_prerequisites()
+{
+    if (version_compare(GLPI_VERSION, '9.5.5', '<')) {
+        Session::addMessageAfterRedirect(
+            __('This plugin requires GLPI 9.5.5 or higher.', 'autoassign'),
+            false,
+            ERROR
+        );
+        return false;
+    }
+
+    return true;
+}
+
+function plugin_autoassign_check_config($verbose = false)
+{
+    if ($verbose) {
+        echo __('Installed / not configured', 'autoassign');
+    }
+    return true;
+}
+
+function plugin_init_autoassign()
+{
+    global $PLUGIN_HOOKS;
+
+    $PLUGIN_HOOKS['csrf_compliant']['autoassign'] = true;
+    $PLUGIN_HOOKS['config_page']['autoassign']    = 'front/config.form.php';
+    $PLUGIN_HOOKS['login']['autoassign']          = 'plugin_autoassign_force_showall';
+    $PLUGIN_HOOKS['post_item_add']['autoassign']  = 'plugin_autoassign_post_item_add';
+
+    Plugin::registerClass('PluginAutoassignConfig');
+}
+
+function plugin_autoassign_install()
+{
+    global $DB;
+
+    $table = 'glpi_plugin_autoassign_config';
+
+    if (!$DB->tableExists($table)) {
+        $query = "CREATE TABLE `{$table}` (
+            `id` int(11) NOT NULL AUTO_INCREMENT,
+            `profiles_id` int(11) DEFAULT NULL,
+            `groups_id` int(11) DEFAULT NULL,
+            `entities_id` int(11) DEFAULT NULL,
+            `force_showall` tinyint(1) NOT NULL DEFAULT '0',
+            `autoassign_task` tinyint(1) NOT NULL DEFAULT '0',
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+        $DB->query($query);
+    }
+
+    return true;
+}
+
+function plugin_autoassign_uninstall()
+{
+    global $DB;
+
+    $table = 'glpi_plugin_autoassign_config';
+
+    if ($DB->tableExists($table)) {
+        $DB->query("DROP TABLE `{$table}`");
+    }
+
+    return true;
+}
+
+function plugin_autoassign_getConfigPage()
+{
+    if (Session::haveRight('config', READ)) {
+        return 'front/config.form.php';
+    }
+
+    return false;
+}


### PR DESCRIPTION
## Summary
- add plugin setup to register hooks and manage the configuration table
- implement login and ticket task hooks to force show all entities and auto-assign technicians
- provide configuration model and admin form for managing auto-assign rules

## Testing
- php -l glpi/plugins/autoassign/setup.php
- php -l glpi/plugins/autoassign/hook.php
- php -l glpi/plugins/autoassign/inc/autoassign.class.php
- php -l glpi/plugins/autoassign/front/config.form.php

------
https://chatgpt.com/codex/tasks/task_e_68dd3dca37788331b0f04da6c576e09c