### PR TITLE
feat: migrate plugin to rule-based configuration

### DIFF
--- a/glpi/plugins/autoassign/front/config.form.php
+++ b/glpi/plugins/autoassign/front/config.form.php
@@ -12,42 +12,51 @@ if (!$plugin->isInstalled('autoassign') || !$plugin->isActivated('autoassign')) 
     Html::displayNotFoundError();
 }
 
-$config = new PluginAutoassignConfig();
-
-if (isset($_POST['add'])) {
-    $config->check(-1, CREATE, $_POST);
-    $config->add($_POST);
-    Html::redirect($CFG_GLPI['root_doc'] . '/plugins/autoassign/front/config.form.php');
-}
-
-if (isset($_POST['update'])) {
-    $config->check($_POST['id'], UPDATE);
-    $config->update($_POST);
-    Html::redirect($CFG_GLPI['root_doc'] . '/plugins/autoassign/front/config.form.php');
-}
-
-if (isset($_POST['delete'])) {
-    $config->check($_POST['id'], DELETE);
-    $config->delete($_POST);
-    Html::redirect($CFG_GLPI['root_doc'] . '/plugins/autoassign/front/config.form.php');
-}
-
-if (isset($_POST['purge'])) {
-    $config->check($_POST['id'], PURGE);
-    $config->delete($_POST, true);
-    Html::redirect($CFG_GLPI['root_doc'] . '/plugins/autoassign/front/config.form.php');
-}
-
-$ID = isset($_GET['id']) ? (int) $_GET['id'] : 0;
-
 Html::header(__('Auto Assign & ShowAll', 'autoassign'), $_SERVER['PHP_SELF'], 'config', 'plugins', 'autoassign');
 
 echo "<div class='spaced'>";
-$config->showForm($ID);
-echo '</div>';
 
-echo "<div class='spaced'>";
-Search::show('PluginAutoassignConfig');
+$showallUrl = $CFG_GLPI['root_doc'] . '/plugins/autoassign/front/rule_showall.php';
+$assignUrl  = $CFG_GLPI['root_doc'] . '/plugins/autoassign/front/rule_assign.php';
+
+echo "<table class='tab_cadre_fixe'>";
+
+echo "<tr><th colspan='2'>" . __('Manage rules', 'autoassign') . '</th></tr>';
+
+echo "<tr class='tab_bg_1'>";
+
+echo "<td><strong>" . __('Entity visibility rules', 'autoassign') . "</strong><br>";
+
+echo __('Configure which users, groups, profiles or entities should automatically see every entity on login.', 'autoassign');
+
+echo '</td>';
+
+echo "<td class='center'>";
+
+echo "<a class='vsubmit' href='{$showallUrl}'>" . __('Open rules', 'autoassign') . '</a>';
+
+echo '</td>';
+
+echo '</tr>';
+
+echo "<tr class='tab_bg_1'>";
+
+echo "<td><strong>" . __('Task based ticket assignments', 'autoassign') . "</strong><br>";
+
+echo __('Define criteria to automatically assign technicians or groups to tickets when they are added to tasks.', 'autoassign');
+
+echo '</td>';
+
+echo "<td class='center'>";
+
+echo "<a class='vsubmit' href='{$assignUrl}'>" . __('Open rules', 'autoassign') . '</a>';
+
+echo '</td>';
+
+echo '</tr>';
+
+echo '</table>';
+
 echo '</div>';
 
 Html::footer();

--- a/glpi/plugins/autoassign/front/rule_assign.php
+++ b/glpi/plugins/autoassign/front/rule_assign.php
@@ -1,0 +1,10 @@
+<?php
+
+include '../../../inc/includes.php';
+require_once __DIR__ . '/../inc/autoassign.class.php';
+
+Session::checkRight('config', READ);
+
+$rulecollection = new PluginAutoassignRuleAssignCollection();
+
+include GLPI_ROOT . '/front/rule.common.php';

--- a/glpi/plugins/autoassign/front/rule_showall.php
+++ b/glpi/plugins/autoassign/front/rule_showall.php
@@ -1,0 +1,10 @@
+<?php
+
+include '../../../inc/includes.php';
+require_once __DIR__ . '/../inc/autoassign.class.php';
+
+Session::checkRight('config', READ);
+
+$rulecollection = new PluginAutoassignRuleShowAllCollection();
+
+include GLPI_ROOT . '/front/rule.common.php';

--- a/glpi/plugins/autoassign/hook.php
+++ b/glpi/plugins/autoassign/hook.php
@@ -1,18 +1,20 @@
 <?php
 
 if (!defined('GLPI_ROOT')) {
-    die('Sorry. You can\'t access directly to this file');
+    die("Sorry. You can't access directly to this file");
 }
+
+require_once __DIR__ . '/inc/autoassign.class.php';
 
 function plugin_autoassign_force_showall($params = [])
 {
-    $userID = Session::getLoginUserID();
+    $userID = (int) Session::getLoginUserID();
 
-    if (empty($userID)) {
+    if ($userID <= 0) {
         return;
     }
 
-    if (plugin_autoassign_user_matches_rule((int) $userID, 'force_showall')) {
+    if (PluginAutoassignRuleHelper::shouldForceShowAll($userID)) {
         $_SESSION['glpishowallentities'] = 1;
     }
 }
@@ -24,137 +26,25 @@ function plugin_autoassign_post_item_add(CommonDBTM $item)
     }
 
     $userID   = (int) ($item->fields['users_id_tech'] ?? 0);
+    $groupID  = (int) ($item->fields['groups_id_tech'] ?? 0);
     $ticketID = (int) ($item->fields['tickets_id'] ?? 0);
 
-    if ($userID <= 0 || $ticketID <= 0) {
+    if (($userID <= 0 && $groupID <= 0) || $ticketID <= 0) {
         return;
     }
 
-    if (!plugin_autoassign_user_matches_rule($userID, 'autoassign_task')) {
+    $ticket = new Ticket();
+    if (!$ticket->getFromDB($ticketID)) {
         return;
     }
 
-    global $DB;
+    $targets = PluginAutoassignRuleHelper::getAutoAssignTargets($ticket);
 
-    $existing = $DB->request([
-        'FROM'  => 'glpi_tickets_users',
-        'WHERE' => [
-            'tickets_id' => $ticketID,
-            'users_id'   => $userID,
-            'type'       => CommonITILActor::ASSIGN,
-        ],
-        'LIMIT' => 1,
-    ]);
-
-    if ($existing) {
-        foreach ($existing as $row) {
-            return;
-        }
+    if ($userID > 0 && in_array($userID, $targets['users'], true)) {
+        PluginAutoassignRuleHelper::ensureUserAssignment($ticketID, $userID);
     }
 
-    $ticketUser = new Ticket_User();
-    $ticketUser->add([
-        'tickets_id' => $ticketID,
-        'users_id'   => $userID,
-        'type'       => CommonITILActor::ASSIGN,
-    ]);
-}
-
-function plugin_autoassign_user_matches_rule($userID, $flagField)
-{
-    global $DB;
-
-    if ($userID <= 0) {
-        return false;
+    if ($groupID > 0 && in_array($groupID, $targets['groups'], true)) {
+        PluginAutoassignRuleHelper::ensureGroupAssignment($ticketID, $groupID);
     }
-
-    $memberships = plugin_autoassign_get_user_memberships($userID);
-
-    if (empty($memberships)) {
-        return false;
-    }
-
-    $iterator = $DB->request([
-        'FROM'  => 'glpi_plugin_autoassign_configs',
-        'WHERE' => [
-            $flagField => 1,
-        ],
-    ]);
-
-    foreach ($iterator as $rule) {
-        $profileID = isset($rule['profiles_id']) ? (int) $rule['profiles_id'] : null;
-        $groupID   = isset($rule['groups_id']) ? (int) $rule['groups_id'] : null;
-        $entityID  = isset($rule['entities_id']) ? (int) $rule['entities_id'] : null;
-
-        if ($profileID && in_array($profileID, $memberships['profiles'], true)) {
-            return true;
-        }
-
-        if ($groupID && in_array($groupID, $memberships['groups'], true)) {
-            return true;
-        }
-
-        if ($entityID !== null && in_array($entityID, $memberships['entities'], true)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-function plugin_autoassign_get_user_memberships($userID)
-{
-    global $DB;
-
-    static $cache = [];
-
-    if (isset($cache[$userID])) {
-        return $cache[$userID];
-    }
-
-    $profiles = [];
-    $groups   = [];
-    $entities = [];
-
-    $profileIterator = $DB->request([
-        'SELECT' => ['profiles_id', 'entities_id'],
-        'FROM'   => 'glpi_profiles_users',
-        'WHERE'  => ['users_id' => $userID],
-    ]);
-
-    foreach ($profileIterator as $row) {
-        if ($row['profiles_id'] !== null) {
-            $profiles[] = (int) $row['profiles_id'];
-        }
-        if ($row['entities_id'] !== null) {
-            $entities[] = (int) $row['entities_id'];
-        }
-    }
-
-    $groupIterator = $DB->request([
-        'SELECT' => 'groups_id',
-        'FROM'   => 'glpi_groups_users',
-        'WHERE'  => ['users_id' => $userID],
-    ]);
-
-    foreach ($groupIterator as $row) {
-        if ($row['groups_id'] !== null) {
-            $groups[] = (int) $row['groups_id'];
-        }
-    }
-
-    $user = new User();
-    if ($user->getFromDB($userID)) {
-        if (isset($user->fields['entities_id']) && $user->fields['entities_id'] !== null) {
-            $entities[] = (int) $user->fields['entities_id'];
-        }
-    }
-
-    $cache[$userID] = [
-        'profiles' => array_values(array_unique($profiles)),
-        'groups'   => array_values(array_unique($groups)),
-        'entities' => array_values(array_unique($entities)),
-    ];
-
-    return $cache[$userID];
 }

--- a/glpi/plugins/autoassign/inc/autoassign.class.php
+++ b/glpi/plugins/autoassign/inc/autoassign.class.php
@@ -1,229 +1,464 @@
 <?php
 
 if (!defined('GLPI_ROOT')) {
-    die('Sorry. You can\'t access directly to this file');
+    die("Sorry. You can't access directly to this file");
 }
 
-class PluginAutoassignConfig extends CommonDBTM
+class PluginAutoassignRuleShowAllCollection extends RuleCollection
 {
-    public static $rightname = 'config';
+    public $menu_type   = 'plugins';
+    public $menu_option = 'autoassign';
 
-    public static $table = 'glpi_plugin_autoassign_configs';
-
-    public static function getTypeName($nb = 0)
+    public function getTitle()
     {
-        return _n('Auto assign rule', 'Auto assign rules', $nb, 'autoassign');
+        return __('Rules for entity visibility override', 'autoassign');
     }
 
-    public function prepareInputForAdd($input)
+    public function canList()
     {
-        $input = parent::prepareInputForAdd($input);
-        if ($input === false) {
-            return false;
+        return Session::haveRight('config', READ);
+    }
+
+    public function prepareInputDataForProcess($input, $params)
+    {
+        $userID = (int) ($params['users_id'] ?? $input['users_id'] ?? 0);
+
+        if ($userID <= 0) {
+            return $input;
         }
 
-        return $this->sanitizeInput($input);
-    }
+        $fields = array_map('Toolbox::strtolower', $this->getFieldsToLookFor());
 
-    public function prepareInputForUpdate($input)
-    {
-        $input = parent::prepareInputForUpdate($input);
-        if ($input === false) {
-            return false;
+        $input['users_id'] = $userID;
+
+        if (in_array('profiles_id', $fields, true)) {
+            $input['profiles_id'] = PluginAutoassignRuleHelper::getUserProfiles($userID);
         }
 
-        return $this->sanitizeInput($input);
-    }
-
-    public function rawSearchOptions()
-    {
-        $tab = [];
-
-        $tab[] = [
-            'id'   => 'common',
-            'name' => __('Characteristics'),
-        ];
-
-        $tab[] = [
-            'id'            => 1,
-            'table'         => self::$table,
-            'field'         => 'id',
-            'name'          => __('ID'),
-            'datatype'      => 'number',
-            'massiveaction' => false,
-        ];
-
-        $tab[] = [
-            'id'            => 2,
-            'table'         => self::$table,
-            'field'         => 'profiles_id',
-            'name'          => __('Profile'),
-            'datatype'      => 'dropdown',
-            'massiveaction' => false,
-        ];
-
-        $tab[] = [
-            'id'            => 3,
-            'table'         => self::$table,
-            'field'         => 'groups_id',
-            'name'          => __('Group'),
-            'datatype'      => 'dropdown',
-            'massiveaction' => false,
-        ];
-
-        $tab[] = [
-            'id'            => 4,
-            'table'         => self::$table,
-            'field'         => 'entities_id',
-            'name'          => __('Entity'),
-            'datatype'      => 'dropdown',
-            'massiveaction' => false,
-        ];
-
-        $tab[] = [
-            'id'            => 5,
-            'table'         => self::$table,
-            'field'         => 'force_showall',
-            'name'          => __('Force show all entities', 'autoassign'),
-            'datatype'      => 'bool',
-            'massiveaction' => false,
-        ];
-
-        $tab[] = [
-            'id'            => 6,
-            'table'         => self::$table,
-            'field'         => 'autoassign_task',
-            'name'          => __('Auto assign task technician', 'autoassign'),
-            'datatype'      => 'bool',
-            'massiveaction' => false,
-        ];
-
-        return $tab;
-    }
-
-    private function sanitizeInput(array $input)
-    {
-        foreach (['profiles_id', 'groups_id', 'entities_id'] as $field) {
-            if (!array_key_exists($field, $input)) {
-                continue;
-            }
-
-            if ($input[$field] === '' || $input[$field] === null) {
-                $input[$field] = null;
-                continue;
-            }
-
-            $value = (int) $input[$field];
-
-            if ($field === 'entities_id') {
-                $input[$field] = $value;
-            } else {
-                $input[$field] = $value > 0 ? $value : null;
-            }
+        if (in_array('groups_id', $fields, true)) {
+            $input['groups_id'] = PluginAutoassignRuleHelper::getUserGroups($userID);
         }
 
-        $input['force_showall']   = isset($input['force_showall']) ? 1 : 0;
-        $input['autoassign_task'] = isset($input['autoassign_task']) ? 1 : 0;
+        if (in_array('entities_id', $fields, true)) {
+            $input['entities_id'] = PluginAutoassignRuleHelper::getUserEntities($userID);
+        }
 
         return $input;
     }
+}
 
-    public static function canView()
+class PluginAutoassignRuleShowAll extends Rule
+{
+    public $can_sort = true;
+
+    public static function getTypeName($nb = 0)
     {
-        return Session::haveRight(self::$rightname, READ);
+        return _n('Show all rule', 'Show all rules', $nb, 'autoassign');
     }
 
-    public static function canCreate()
+    public function getTitle()
     {
-        return Session::haveRight(self::$rightname, UPDATE);
+        return __('Rules for entity visibility override', 'autoassign');
     }
 
-    public static function canUpdate()
+    public function getCriterias()
     {
-        return Session::haveRight(self::$rightname, UPDATE);
+        $criterias = [];
+
+        $criterias['users_id']['field'] = 'name';
+        $criterias['users_id']['name']  = __('User');
+        $criterias['users_id']['table'] = User::getTable();
+        $criterias['users_id']['type']  = 'dropdown_users';
+
+        $criterias['profiles_id']['field']   = 'name';
+        $criterias['profiles_id']['name']    = Profile::getTypeName(1);
+        $criterias['profiles_id']['table']   = Profile::getTable();
+        $criterias['profiles_id']['type']    = 'dropdown';
+        $criterias['profiles_id']['virtual'] = true;
+
+        $criterias['groups_id']['field']     = 'completename';
+        $criterias['groups_id']['name']      = Group::getTypeName(1);
+        $criterias['groups_id']['table']     = Group::getTable();
+        $criterias['groups_id']['type']      = 'dropdown';
+        $criterias['groups_id']['virtual']   = true;
+        $criterias['groups_id']['condition'] = ['is_assign' => 1];
+
+        $criterias['entities_id']['field']           = 'completename';
+        $criterias['entities_id']['name']            = Entity::getTypeName(1);
+        $criterias['entities_id']['table']           = Entity::getTable();
+        $criterias['entities_id']['type']            = 'dropdown';
+        $criterias['entities_id']['virtual']         = true;
+        $criterias['entities_id']['allow_condition'] = [
+            Rule::PATTERN_IS,
+            Rule::PATTERN_UNDER,
+            Rule::PATTERN_NOT_UNDER,
+        ];
+
+        return $criterias;
     }
 
-    public static function canDelete()
+    public function getActions()
     {
-        return Session::haveRight(self::$rightname, UPDATE);
+        $actions = [];
+
+        $actions['force_showall']['name']          = __('Force show all entities', 'autoassign');
+        $actions['force_showall']['type']          = 'yesonly';
+        $actions['force_showall']['force_actions'] = ['assign'];
+
+        return $actions;
     }
 
-    public static function canPurge()
+    public function maxActionsCount()
     {
-        return Session::haveRight(self::$rightname, UPDATE);
+        return 1;
+    }
+}
+
+class PluginAutoassignRuleAssignCollection extends RuleCollection
+{
+    public $menu_type             = 'plugins';
+    public $menu_option           = 'autoassign';
+    public $stop_on_first_match   = false;
+
+    public function getTitle()
+    {
+        return __('Rules for task driven assignments', 'autoassign');
     }
 
-    public function getSpecificMassiveActions($checkitem = null)
+    public function canList()
     {
-        return [];
+        return Session::haveRight('config', READ);
     }
 
-    public function showForm($ID, array $options = [])
+    public function prepareInputDataForProcess($input, $params)
     {
-        if ($ID > 0) {
-            $this->check($ID, READ);
-        } else {
-            $this->getEmpty();
+        $ticketFields = [];
+        if (isset($params['ticket']) && is_array($params['ticket'])) {
+            $ticketFields = $params['ticket'];
+        } elseif (isset($input['id'])) {
+            $ticketFields = $input;
+        }
 
-            if (!self::canCreate()) {
-                Html::displayRightError();
+        if (empty($ticketFields)) {
+            return $input;
+        }
+
+        $fields = array_map('Toolbox::strtolower', $this->getFieldsToLookFor());
+
+        foreach (['entities_id', 'type', 'itilcategories_id', 'status', 'requesttypes_id', 'global_validation', 'priority'] as $field) {
+            if (in_array($field, $fields, true) && array_key_exists($field, $ticketFields)) {
+                $input[$field] = $ticketFields[$field];
             }
         }
 
-        $this->initForm($ID, $options);
-        $this->showFormHeader($options);
+        if (in_array('tag', $fields, true)) {
+            $input['tag'] = PluginAutoassignRuleHelper::getTicketTags((int) ($ticketFields['id'] ?? 0), $ticketFields);
+        }
 
-        echo "<tr class='tab_bg_1'>";
-        echo '<td>' . __('Profile') . '</td>';
-        echo '<td>';
-        Profile::dropdown([
-            'name'                  => 'profiles_id',
-            'value'                 => $this->fields['profiles_id'] ?? 0,
-            'display_emptychoice'   => true,
-            'checkright'            => false,
-        ]);
-        echo '</td>';
-        echo '<td>' . __('Force show all entities', 'autoassign') . '</td>';
-        echo '<td>';
-        Html::showCheckbox([
-            'name'    => 'force_showall',
-            'checked' => !empty($this->fields['force_showall']),
-        ]);
-        echo '</td>';
-        echo '</tr>';
+        return $input;
+    }
+}
 
-        echo "<tr class='tab_bg_1'>";
-        echo '<td>' . __('Group') . '</td>';
-        echo '<td>';
-        Group::dropdown([
-            'name'                => 'groups_id',
-            'value'               => $this->fields['groups_id'] ?? 0,
-            'display_emptychoice' => true,
-        ]);
-        echo '</td>';
-        echo '<td>' . __('Auto assign task technician', 'autoassign') . '</td>';
-        echo '<td>';
-        Html::showCheckbox([
-            'name'    => 'autoassign_task',
-            'checked' => !empty($this->fields['autoassign_task']),
-        ]);
-        echo '</td>';
-        echo '</tr>';
+class PluginAutoassignRuleAssign extends Rule
+{
+    public $can_sort = true;
 
-        echo "<tr class='tab_bg_1'>";
-        echo '<td>' . __('Entity') . '</td>';
-        echo '<td>';
-        Entity::dropdown([
-            'name'                => 'entities_id',
-            'value'               => $this->fields['entities_id'] ?? 0,
-            'display_emptychoice' => true,
-        ]);
-        echo '</td>';
-        echo '<td colspan="2"></td>';
-        echo '</tr>';
+    public static function getTypeName($nb = 0)
+    {
+        return _n('Auto assignment rule', 'Auto assignment rules', $nb, 'autoassign');
+    }
 
-        $this->showFormButtons($options);
+    public function getTitle()
+    {
+        return __('Rules for task driven assignments', 'autoassign');
+    }
 
+    public function maybeRecursive()
+    {
         return true;
+    }
+
+    public function isEntityAssign()
+    {
+        return true;
+    }
+
+    public function getCriterias()
+    {
+        $criterias = [];
+
+        $criterias['entities_id']['field']           = 'completename';
+        $criterias['entities_id']['name']            = Entity::getTypeName(1);
+        $criterias['entities_id']['table']           = Entity::getTable();
+        $criterias['entities_id']['type']            = 'dropdown';
+        $criterias['entities_id']['allow_condition'] = [
+            Rule::PATTERN_IS,
+            Rule::PATTERN_UNDER,
+            Rule::PATTERN_NOT_UNDER,
+        ];
+
+        $criterias['tag']['name'] = __('Tag');
+        $criterias['tag']['type'] = 'text';
+
+        $criterias['type']['name']      = __('Type');
+        $criterias['type']['type']      = 'dropdown_tickettype';
+        $criterias['type']['linkfield'] = 'type';
+
+        $criterias['itilcategories_id']['field'] = 'completename';
+        $criterias['itilcategories_id']['name']  = ITILCategory::getTypeName(1);
+        $criterias['itilcategories_id']['table'] = ITILCategory::getTable();
+        $criterias['itilcategories_id']['type']  = 'dropdown';
+
+        $criterias['status']['name'] = __('Status');
+        $criterias['status']['type'] = 'dropdown_status';
+
+        $criterias['requesttypes_id']['field'] = 'name';
+        $criterias['requesttypes_id']['name']  = RequestType::getTypeName(1);
+        $criterias['requesttypes_id']['table'] = RequestType::getTable();
+        $criterias['requesttypes_id']['type']  = 'dropdown';
+
+        $criterias['global_validation']['name'] = __('Approval', 'autoassign');
+        $criterias['global_validation']['type'] = 'dropdown_validation';
+
+        $criterias['priority']['name'] = __('Priority');
+        $criterias['priority']['type'] = 'dropdown_priority';
+
+        return $criterias;
+    }
+
+    public function getActions()
+    {
+        $actions = [];
+
+        $actions['autoassign_user']['name']               = __('Auto assign user', 'autoassign');
+        $actions['autoassign_user']['type']               = 'dropdown_users';
+        $actions['autoassign_user']['table']              = User::getTable();
+        $actions['autoassign_user']['force_actions']      = ['append'];
+        $actions['autoassign_user']['permitseveral']      = ['append'];
+        $actions['autoassign_user']['appendto']           = '_autoassign_users';
+        $actions['autoassign_user']['appendtoarray']      = [];
+        $actions['autoassign_user']['appendtoarrayfield'] = 'users_id';
+
+        $actions['autoassign_group']['name']               = __('Auto assign group', 'autoassign');
+        $actions['autoassign_group']['type']               = 'dropdown';
+        $actions['autoassign_group']['table']              = Group::getTable();
+        $actions['autoassign_group']['condition']          = ['is_assign' => 1];
+        $actions['autoassign_group']['force_actions']      = ['append'];
+        $actions['autoassign_group']['permitseveral']      = ['append'];
+        $actions['autoassign_group']['appendto']           = '_autoassign_groups';
+        $actions['autoassign_group']['appendtoarray']      = [];
+        $actions['autoassign_group']['appendtoarrayfield'] = 'groups_id';
+
+        return $actions;
+    }
+}
+
+class PluginAutoassignRuleHelper
+{
+    private static $memberships = [];
+
+    public static function shouldForceShowAll($userID)
+    {
+        if ($userID <= 0) {
+            return false;
+        }
+
+        $collection = new PluginAutoassignRuleShowAllCollection();
+        $result     = $collection->processAllRules(
+            ['users_id' => $userID],
+            [],
+            ['users_id' => $userID]
+        );
+
+        $result = Toolbox::stripslashes_deep($result);
+
+        if (isset($result['force_showall'])) {
+            return (int) $result['force_showall'] === 1;
+        }
+
+        return false;
+    }
+
+    public static function getAutoAssignTargets(Ticket $ticket)
+    {
+        $collection = new PluginAutoassignRuleAssignCollection();
+        $result     = $collection->processAllRules(
+            $ticket->fields,
+            [],
+            ['ticket' => $ticket->fields]
+        );
+
+        $result = Toolbox::stripslashes_deep($result);
+
+        $users  = [];
+        $groups = [];
+
+        if (!empty($result['_autoassign_users'])) {
+            foreach ($result['_autoassign_users'] as $data) {
+                if (!is_array($data)) {
+                    continue;
+                }
+                $users[] = (int) ($data['users_id'] ?? 0);
+            }
+        }
+
+        if (!empty($result['_autoassign_groups'])) {
+            foreach ($result['_autoassign_groups'] as $data) {
+                if (!is_array($data)) {
+                    continue;
+                }
+                $groups[] = (int) ($data['groups_id'] ?? 0);
+            }
+        }
+
+        return [
+            'users'  => array_values(array_unique(array_filter($users))),
+            'groups' => array_values(array_unique(array_filter($groups))),
+        ];
+    }
+
+    public static function ensureUserAssignment($ticketID, $userID)
+    {
+        if ($ticketID <= 0 || $userID <= 0) {
+            return;
+        }
+
+        global $DB;
+
+        $iterator = $DB->request([
+            'FROM'  => 'glpi_tickets_users',
+            'WHERE' => [
+                'tickets_id' => $ticketID,
+                'users_id'   => $userID,
+                'type'       => CommonITILActor::ASSIGN,
+            ],
+            'LIMIT' => 1,
+        ]);
+
+        foreach ($iterator as $row) {
+            return;
+        }
+
+        $ticketUser = new Ticket_User();
+        $ticketUser->add([
+            'tickets_id' => $ticketID,
+            'users_id'   => $userID,
+            'type'       => CommonITILActor::ASSIGN,
+        ]);
+    }
+
+    public static function ensureGroupAssignment($ticketID, $groupID)
+    {
+        if ($ticketID <= 0 || $groupID <= 0) {
+            return;
+        }
+
+        global $DB;
+
+        $iterator = $DB->request([
+            'FROM'  => 'glpi_groups_tickets',
+            'WHERE' => [
+                'tickets_id' => $ticketID,
+                'groups_id'  => $groupID,
+                'type'       => CommonITILActor::ASSIGN,
+            ],
+            'LIMIT' => 1,
+        ]);
+
+        foreach ($iterator as $row) {
+            return;
+        }
+
+        $ticketGroup = new Group_Ticket();
+        $ticketGroup->add([
+            'tickets_id' => $ticketID,
+            'groups_id'  => $groupID,
+            'type'       => CommonITILActor::ASSIGN,
+        ]);
+    }
+
+    public static function getUserProfiles($userID)
+    {
+        if ($userID <= 0) {
+            return [];
+        }
+
+        if (!isset(self::$memberships[$userID]['profiles'])) {
+            $profiles = [];
+            foreach (Profile_User::getUserProfiles($userID) as $profile) {
+                if (isset($profile['profiles_id'])) {
+                    $profiles[] = (int) $profile['profiles_id'];
+                }
+            }
+            self::$memberships[$userID]['profiles'] = array_values(array_unique($profiles));
+        }
+
+        return self::$memberships[$userID]['profiles'];
+    }
+
+    public static function getUserGroups($userID)
+    {
+        if ($userID <= 0) {
+            return [];
+        }
+
+        if (!isset(self::$memberships[$userID]['groups'])) {
+            $groups = [];
+            foreach (Group_User::getUserGroups($userID) as $group) {
+                if (isset($group['id'])) {
+                    $groups[] = (int) $group['id'];
+                }
+            }
+            self::$memberships[$userID]['groups'] = array_values(array_unique($groups));
+        }
+
+        return self::$memberships[$userID]['groups'];
+    }
+
+    public static function getUserEntities($userID)
+    {
+        if ($userID <= 0) {
+            return [];
+        }
+
+        if (!isset(self::$memberships[$userID]['entities'])) {
+            $entities = Profile_User::getUserEntities($userID, true, true);
+            self::$memberships[$userID]['entities'] = array_values(array_unique(array_map('intval', $entities)));
+        }
+
+        return self::$memberships[$userID]['entities'];
+    }
+
+    public static function getTicketTags($ticketID, array $ticketFields = [])
+    {
+        $tags = [];
+
+        if ($ticketID > 0 && class_exists('Tag')) {
+            $tag = new Tag();
+
+            if (method_exists($tag, 'getListForItem')) {
+                foreach ((array) $tag->getListForItem('Ticket', $ticketID) as $tagRow) {
+                    if (isset($tagRow['tag'])) {
+                        $tags[] = $tagRow['tag'];
+                    } elseif (isset($tagRow['name'])) {
+                        $tags[] = $tagRow['name'];
+                    }
+                }
+            } elseif (method_exists($tag, 'getForItem')) {
+                foreach ((array) $tag->getForItem('Ticket', $ticketID) as $tagRow) {
+                    if (isset($tagRow['tag'])) {
+                        $tags[] = $tagRow['tag'];
+                    } elseif (isset($tagRow['name'])) {
+                        $tags[] = $tagRow['name'];
+                    }
+                }
+            }
+        }
+
+        if (empty($tags) && isset($ticketFields['tag'])) {
+            $tags[] = $ticketFields['tag'];
+        }
+
+        return array_values(array_filter(array_unique($tags)));
     }
 }

--- a/glpi/plugins/autoassign/setup.php
+++ b/glpi/plugins/autoassign/setup.php
@@ -1,11 +1,12 @@
 <?php
 
 if (!defined('GLPI_ROOT')) {
-    die('Sorry. You can\'t access directly to this file');
+    die("Sorry. You can't access directly to this file");
 }
 
-define('PLUGIN_AUTOASSIGN_VERSION', '1.0.0');
-define('PLUGIN_AUTOASSIGN_TABLE', 'glpi_plugin_autoassign_configs');
+define('PLUGIN_AUTOASSIGN_VERSION', '2.0.0');
+
+define('PLUGIN_AUTOASSIGN_LEGACY_TABLE', 'glpi_plugin_autoassign_configs');
 
 function plugin_version_autoassign()
 {
@@ -49,28 +50,14 @@ function plugin_init_autoassign()
     $PLUGIN_HOOKS['config_page']['autoassign']    = 'front/config.form.php';
     $PLUGIN_HOOKS['login']['autoassign']          = 'plugin_autoassign_force_showall';
     $PLUGIN_HOOKS['post_item_add']['autoassign']  = 'plugin_autoassign_post_item_add';
-
-    Plugin::registerClass('PluginAutoassignConfig');
 }
 
 function plugin_autoassign_install()
 {
     global $DB;
 
-    $table = PLUGIN_AUTOASSIGN_TABLE;
-
-    if (!$DB->tableExists($table)) {
-        $query = "CREATE TABLE `{$table}` (
-            `id` int(11) NOT NULL AUTO_INCREMENT,
-            `profiles_id` int(11) DEFAULT NULL,
-            `groups_id` int(11) DEFAULT NULL,
-            `entities_id` int(11) DEFAULT NULL,
-            `force_showall` tinyint(1) NOT NULL DEFAULT '0',
-            `autoassign_task` tinyint(1) NOT NULL DEFAULT '0',
-            PRIMARY KEY (`id`)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
-
-        $DB->query($query);
+    if ($DB->tableExists(PLUGIN_AUTOASSIGN_LEGACY_TABLE)) {
+        $DB->query("DROP TABLE `" . PLUGIN_AUTOASSIGN_LEGACY_TABLE . "`");
     }
 
     return true;
@@ -78,14 +65,6 @@ function plugin_autoassign_install()
 
 function plugin_autoassign_uninstall()
 {
-    global $DB;
-
-    $table = PLUGIN_AUTOASSIGN_TABLE;
-
-    if ($DB->tableExists($table)) {
-        $DB->query("DROP TABLE `{$table}`");
-    }
-
     return true;
 }
 


### PR DESCRIPTION
## Summary
- replace the legacy configuration table with rule collections for show-all and auto-assignment features
- add rule management entry points and helper logic to evaluate rules on login and task creation
- update plugin setup and configuration UI to focus on the new rule-driven workflow

## Testing
- php -l glpi/plugins/autoassign/inc/autoassign.class.php
- php -l glpi/plugins/autoassign/hook.php
- php -l glpi/plugins/autoassign/setup.php
- php -l glpi/plugins/autoassign/front/config.form.php
- php -l glpi/plugins/autoassign/front/rule_showall.php
- php -l glpi/plugins/autoassign/front/rule_assign.php

------
https://chatgpt.com/codex/tasks/task_e_68dd5a3f6cbc8331890aff86173a8d72