### PR TITLE
Fix rule pages autoloading and localize UI text

### DIFF
--- a/glpi/plugins/autoassign/front/config.form.php
+++ b/glpi/plugins/autoassign/front/config.form.php
@@ -1,7 +1,7 @@
 <?php
 
 include '../../../inc/includes.php';
-require_once __DIR__ . '/../inc/autoassign.class.php';
+require_once __DIR__ . '/../inc/autoload.php';
 
 global $CFG_GLPI;
 
@@ -12,7 +12,7 @@ if (!$plugin->isInstalled('autoassign') || !$plugin->isActivated('autoassign')) 
     Html::displayNotFoundError();
 }
 
-Html::header(__('Auto Assign & ShowAll', 'autoassign'), $_SERVER['PHP_SELF'], 'config', 'plugins', 'autoassign');
+Html::header(__('Atribuição Automática & Mostrar Tudo', 'autoassign'), $_SERVER['PHP_SELF'], 'config', 'plugins', 'autoassign');
 
 echo "<div class='spaced'>";
 
@@ -21,19 +21,19 @@ $assignUrl  = $CFG_GLPI['root_doc'] . '/plugins/autoassign/front/rule_assign.php
 
 echo "<table class='tab_cadre_fixe'>";
 
-echo "<tr><th colspan='2'>" . __('Manage rules', 'autoassign') . '</th></tr>';
+echo "<tr><th colspan='2'>" . __('Gerenciar regras', 'autoassign') . '</th></tr>';
 
 echo "<tr class='tab_bg_1'>";
 
-echo "<td><strong>" . __('Entity visibility rules', 'autoassign') . "</strong><br>";
+echo "<td><strong>" . __('Regras de visibilidade de entidades', 'autoassign') . "</strong><br>";
 
-echo __('Configure which users, groups, profiles or entities should automatically see every entity on login.', 'autoassign');
+echo __('Configurar quais usuários, grupos, perfis ou entidades devem visualizar automaticamente todas as entidades ao fazer login.', 'autoassign');
 
 echo '</td>';
 
 echo "<td class='center'>";
 
-echo "<a class='vsubmit' href='{$showallUrl}'>" . __('Open rules', 'autoassign') . '</a>';
+echo "<a class='vsubmit' href='{$showallUrl}'>" . __('Abrir regras', 'autoassign') . '</a>';
 
 echo '</td>';
 
@@ -41,15 +41,15 @@ echo '</tr>';
 
 echo "<tr class='tab_bg_1'>";
 
-echo "<td><strong>" . __('Task based ticket assignments', 'autoassign') . "</strong><br>";
+echo "<td><strong>" . __('Atribuições de chamados baseadas em tarefas', 'autoassign') . "</strong><br>";
 
-echo __('Define criteria to automatically assign technicians or groups to tickets when they are added to tasks.', 'autoassign');
+echo __('Defina critérios para atribuir automaticamente técnicos ou grupos aos chamados quando forem adicionados às tarefas.', 'autoassign');
 
 echo '</td>';
 
 echo "<td class='center'>";
 
-echo "<a class='vsubmit' href='{$assignUrl}'>" . __('Open rules', 'autoassign') . '</a>';
+echo "<a class='vsubmit' href='{$assignUrl}'>" . __('Abrir regras', 'autoassign') . '</a>';
 
 echo '</td>';
 

--- a/glpi/plugins/autoassign/front/rule_assign.php
+++ b/glpi/plugins/autoassign/front/rule_assign.php
@@ -1,7 +1,7 @@
 <?php
 
 include '../../../inc/includes.php';
-require_once __DIR__ . '/../inc/autoassign.class.php';
+require_once __DIR__ . '/../inc/autoload.php';
 
 Session::checkRight('config', READ);
 

--- a/glpi/plugins/autoassign/front/rule_showall.php
+++ b/glpi/plugins/autoassign/front/rule_showall.php
@@ -1,7 +1,7 @@
 <?php
 
 include '../../../inc/includes.php';
-require_once __DIR__ . '/../inc/autoassign.class.php';
+require_once __DIR__ . '/../inc/autoload.php';
 
 Session::checkRight('config', READ);
 

--- a/glpi/plugins/autoassign/hook.php
+++ b/glpi/plugins/autoassign/hook.php
@@ -4,7 +4,7 @@ if (!defined('GLPI_ROOT')) {
     die("Sorry. You can't access directly to this file");
 }
 
-require_once __DIR__ . '/inc/autoassign.class.php';
+require_once __DIR__ . '/inc/autoload.php';
 
 function plugin_autoassign_force_showall($params = [])
 {

--- a/glpi/plugins/autoassign/inc/autoassign.class.php
+++ b/glpi/plugins/autoassign/inc/autoassign.class.php
@@ -11,7 +11,7 @@ class PluginAutoassignRuleShowAllCollection extends RuleCollection
 
     public function getTitle()
     {
-        return __('Rules for entity visibility override', 'autoassign');
+        return __('Regras para substituir a visibilidade de entidades', 'autoassign');
     }
 
     public function canList()
@@ -53,12 +53,12 @@ class PluginAutoassignRuleShowAll extends Rule
 
     public static function getTypeName($nb = 0)
     {
-        return _n('Show all rule', 'Show all rules', $nb, 'autoassign');
+        return _n('Regra para mostrar todas as entidades', 'Regras para mostrar todas as entidades', $nb, 'autoassign');
     }
 
     public function getTitle()
     {
-        return __('Rules for entity visibility override', 'autoassign');
+        return __('Regras para substituir a visibilidade de entidades', 'autoassign');
     }
 
     public function getCriterias()
@@ -101,7 +101,7 @@ class PluginAutoassignRuleShowAll extends Rule
     {
         $actions = [];
 
-        $actions['force_showall']['name']          = __('Force show all entities', 'autoassign');
+        $actions['force_showall']['name']          = __('Forçar exibição de todas as entidades', 'autoassign');
         $actions['force_showall']['type']          = 'yesonly';
         $actions['force_showall']['force_actions'] = ['assign'];
 
@@ -122,7 +122,7 @@ class PluginAutoassignRuleAssignCollection extends RuleCollection
 
     public function getTitle()
     {
-        return __('Rules for task driven assignments', 'autoassign');
+        return __('Regras para atribuições baseadas em tarefas', 'autoassign');
     }
 
     public function canList()
@@ -165,12 +165,12 @@ class PluginAutoassignRuleAssign extends Rule
 
     public static function getTypeName($nb = 0)
     {
-        return _n('Auto assignment rule', 'Auto assignment rules', $nb, 'autoassign');
+        return _n('Regra de atribuição automática', 'Regras de atribuição automática', $nb, 'autoassign');
     }
 
     public function getTitle()
     {
-        return __('Rules for task driven assignments', 'autoassign');
+        return __('Regras para atribuições baseadas em tarefas', 'autoassign');
     }
 
     public function maybeRecursive()
@@ -197,7 +197,7 @@ class PluginAutoassignRuleAssign extends Rule
             Rule::PATTERN_NOT_UNDER,
         ];
 
-        $criterias['tag']['name'] = __('Tag');
+        $criterias['tag']['name'] = __('Etiqueta', 'autoassign');
         $criterias['tag']['type'] = 'text';
 
         $criterias['type']['name']      = __('Type');
@@ -217,10 +217,10 @@ class PluginAutoassignRuleAssign extends Rule
         $criterias['requesttypes_id']['table'] = RequestType::getTable();
         $criterias['requesttypes_id']['type']  = 'dropdown';
 
-        $criterias['global_validation']['name'] = __('Approval', 'autoassign');
+        $criterias['global_validation']['name'] = __('Aprovação', 'autoassign');
         $criterias['global_validation']['type'] = 'dropdown_validation';
 
-        $criterias['priority']['name'] = __('Priority');
+        $criterias['priority']['name'] = __('Prioridade', 'autoassign');
         $criterias['priority']['type'] = 'dropdown_priority';
 
         return $criterias;
@@ -230,7 +230,7 @@ class PluginAutoassignRuleAssign extends Rule
     {
         $actions = [];
 
-        $actions['autoassign_user']['name']               = __('Auto assign user', 'autoassign');
+        $actions['autoassign_user']['name']               = __('Atribuir usuário automaticamente', 'autoassign');
         $actions['autoassign_user']['type']               = 'dropdown_users';
         $actions['autoassign_user']['table']              = User::getTable();
         $actions['autoassign_user']['force_actions']      = ['append'];
@@ -239,7 +239,7 @@ class PluginAutoassignRuleAssign extends Rule
         $actions['autoassign_user']['appendtoarray']      = [];
         $actions['autoassign_user']['appendtoarrayfield'] = 'users_id';
 
-        $actions['autoassign_group']['name']               = __('Auto assign group', 'autoassign');
+        $actions['autoassign_group']['name']               = __('Atribuir grupo automaticamente', 'autoassign');
         $actions['autoassign_group']['type']               = 'dropdown';
         $actions['autoassign_group']['table']              = Group::getTable();
         $actions['autoassign_group']['condition']          = ['is_assign' => 1];

--- a/glpi/plugins/autoassign/inc/autoload.php
+++ b/glpi/plugins/autoassign/inc/autoload.php
@@ -1,0 +1,20 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    die("Sorry. You can't access directly to this file");
+}
+
+if (!defined('PLUGIN_AUTOASSIGN_AUTOLOADER_REGISTERED')) {
+    spl_autoload_register(function ($class) {
+        if (strpos($class, 'PluginAutoassign') !== 0) {
+            return;
+        }
+
+        $filepath = __DIR__ . '/autoassign.class.php';
+        if (is_readable($filepath)) {
+            require_once $filepath;
+        }
+    });
+
+    define('PLUGIN_AUTOASSIGN_AUTOLOADER_REGISTERED', true);
+}

--- a/glpi/plugins/autoassign/setup.php
+++ b/glpi/plugins/autoassign/setup.php
@@ -4,6 +4,8 @@ if (!defined('GLPI_ROOT')) {
     die("Sorry. You can't access directly to this file");
 }
 
+require_once __DIR__ . '/inc/autoload.php';
+
 define('PLUGIN_AUTOASSIGN_VERSION', '2.0.0');
 
 define('PLUGIN_AUTOASSIGN_LEGACY_TABLE', 'glpi_plugin_autoassign_configs');
@@ -11,7 +13,7 @@ define('PLUGIN_AUTOASSIGN_LEGACY_TABLE', 'glpi_plugin_autoassign_configs');
 function plugin_version_autoassign()
 {
     return [
-        'name'           => __('Auto Assign & ShowAll', 'autoassign'),
+        'name'           => __('Atribuição Automática & Mostrar Tudo', 'autoassign'),
         'version'        => PLUGIN_AUTOASSIGN_VERSION,
         'author'         => 'Autoassign Plugin Generator',
         'license'        => 'GPLv2+',
@@ -24,7 +26,7 @@ function plugin_autoassign_check_prerequisites()
 {
     if (version_compare(GLPI_VERSION, '9.5.5', '<')) {
         Session::addMessageAfterRedirect(
-            __('This plugin requires GLPI 9.5.5 or higher.', 'autoassign'),
+            __('Este plugin requer GLPI 9.5.5 ou superior.', 'autoassign'),
             false,
             ERROR
         );
@@ -37,7 +39,7 @@ function plugin_autoassign_check_prerequisites()
 function plugin_autoassign_check_config($verbose = false)
 {
     if ($verbose) {
-        echo __('Installed / not configured', 'autoassign');
+        echo __('Instalado / não configurado', 'autoassign');
     }
     return true;
 }


### PR DESCRIPTION
## Summary
- add a plugin-specific autoloader so rule classes are always available to GLPI requests
- switch the configuration and rule pages to rely on the autoloader and present Portuguese labels
- translate the rule class metadata and actions to Portuguese to match the updated UI

## Testing
- php -l glpi/plugins/autoassign/inc/autoload.php
- php -l glpi/plugins/autoassign/setup.php
- php -l glpi/plugins/autoassign/front/config.form.php
- php -l glpi/plugins/autoassign/front/rule_showall.php
- php -l glpi/plugins/autoassign/front/rule_assign.php
- php -l glpi/plugins/autoassign/inc/autoassign.class.php


------
https://chatgpt.com/codex/tasks/task_e_68dd60ae93ac83318d9e54029bb4df0c